### PR TITLE
Add migrate utility with dotenv setup

### DIFF
--- a/backend/src/utils/migrate.js
+++ b/backend/src/utils/migrate.js
@@ -1,0 +1,17 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+// Load environment variables from the backend .env file
+dotenv.config({ path: path.join(__dirname, '..', '..', '.env') });
+
+// Reference the database URL for migration tools or scripts
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  console.error('DATABASE_URL is not defined');
+  process.exit(1);
+}
+
+console.log(`Running migrations using ${databaseUrl}`);
+// TODO: Add migration logic here
+


### PR DESCRIPTION
## Summary
- add backend `migrate.js` utility
- load environment from backend `.env` via `dotenv`

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b3ece3188323a7eaf0ac4d3c25fa